### PR TITLE
Update homepage with personal details

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,7 +7,15 @@ plugins:
 author:
   name   : "Pim Huijnen"
   avatar : "/images/bio_photo.jpg"
-  bio    : "Digital cultural history"
+  bio    : "Digital cultural historian"
+  location: "Utrecht, NL"
+  links:
+    - label: "GitHub"
+      icon: "fab fa-fw fa-github"
+      url: "https://github.com/pimhuijnen"
+    - label: "Twitter"
+      icon: "fab fa-fw fa-twitter"
+      url: "https://twitter.com/pimhuijnen"
 
 minimal_mistakes_skin: "contrast"
 locale: "en"
@@ -19,3 +27,4 @@ exclude: ["Gemfile", "Gemfile.lock", "node_modules", "vendor"]
 
 header_pages:
   - _pages/blog.md
+  - _pages/about.md

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -4,4 +4,11 @@ title: About
 permalink: /about/
 ---
 
-This is a short about page. You can add more info here about your research, teaching, or projects.
+I am a digital cultural historian at Utrecht University. My work centres on
+understanding how digital sources and methods can help us analyse cultural
+phenomena in the past. On this site I share updates about ongoing research
+projects, links to teaching materials, and notes on public history outreach.
+
+When I'm not working with historical datasets you can find me lecturing on
+digital humanities or blogging about new tools. Feel free to reach out via the
+links below if you'd like to collaborate.

--- a/index.md
+++ b/index.md
@@ -3,4 +3,6 @@ layout: home
 author_profile: true
 ---
 
-Welcome to my personal website.
+Welcome to my personal website. I'm a historian exploring the interaction between 
+digital methods and cultural history. Here you'll find my latest posts and 
+updates about research projects, teaching, and public talks.


### PR DESCRIPTION
## Summary
- set up author links for GitHub and Twitter
- add About page to navigation
- expand the homepage introduction
- write an About page bio

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683ff4ef13f48325a3e05e6ee6b37af6