### PR TITLE
Add navigation pages and landing tabs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -35,5 +35,9 @@ paginate: 5
 exclude: ["Gemfile", "Gemfile.lock", "node_modules", "vendor"]
 
 header_pages:
-  - _pages/blog.md
+  - _pages/posts.md
+  - _pages/research.md
+  - _pages/publications.md
+  - _pages/presentations.md
+  - _pages/teaching.md
   - _pages/about.md

--- a/_pages/posts.md
+++ b/_pages/posts.md
@@ -1,0 +1,8 @@
+---
+layout: archive
+title: "Posts"
+permalink: /posts/
+author_profile: true
+---
+
+Here you'll find my posts.

--- a/_pages/presentations.md
+++ b/_pages/presentations.md
@@ -1,0 +1,7 @@
+---
+layout: page
+title: Presentations
+permalink: /presentations/
+---
+
+Notes and slides from my talks and presentations will appear here.

--- a/_pages/publications.md
+++ b/_pages/publications.md
@@ -1,0 +1,7 @@
+---
+layout: page
+title: Publications
+permalink: /publications/
+---
+
+A list of my academic publications will appear here.

--- a/_pages/research.md
+++ b/_pages/research.md
@@ -1,0 +1,7 @@
+---
+layout: page
+title: Research
+permalink: /research/
+---
+
+Here you'll find information about my ongoing research projects.

--- a/_pages/teaching.md
+++ b/_pages/teaching.md
@@ -1,0 +1,7 @@
+---
+layout: page
+title: Teaching
+permalink: /teaching/
+---
+
+Materials and courses I teach will be listed here.

--- a/blog.md
+++ b/blog.md
@@ -1,8 +1,0 @@
----
-layout: archive
-title: "Blog"
-permalink: /blog/
-author_profile: true
----
-
-Here you’ll find my posts.

--- a/index.md
+++ b/index.md
@@ -3,6 +3,14 @@ layout: home
 author_profile: true
 ---
 
-Welcome to my personal website. I'm a historian exploring the interaction between 
-digital methods and cultural history. Here you'll find my latest posts and 
+Welcome to my personal website. I'm a historian exploring the interaction between
+digital methods and cultural history. Here you'll find my latest posts and
 updates about research projects, teaching, and public talks.
+
+<div class="landing-tabs">
+  <a href="{{ '/posts/' | relative_url }}">Posts</a>
+  <a href="{{ '/research/' | relative_url }}">Research</a>
+  <a href="{{ '/publications/' | relative_url }}">Publications</a>
+  <a href="{{ '/presentations/' | relative_url }}">Presentations</a>
+  <a href="{{ '/teaching/' | relative_url }}">Teaching</a>
+</div>


### PR DESCRIPTION
## Summary
- add dedicated pages for posts, research, publications, presentations and teaching
- expose these pages in the site menu
- link to these pages from tabs on the homepage

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684005dc0c188325a5b73fc7883b75bb