### PR TITLE
Add About link to homepage and reorder navigation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -36,8 +36,8 @@ exclude: ["Gemfile", "Gemfile.lock", "node_modules", "vendor"]
 
 header_pages:
   - _pages/posts.md
+  - _pages/about.md
   - _pages/research.md
   - _pages/publications.md
   - _pages/presentations.md
   - _pages/teaching.md
-  - _pages/about.md

--- a/index.md
+++ b/index.md
@@ -9,6 +9,7 @@ updates about research projects, teaching, and public talks.
 
 <div class="landing-tabs">
   <a href="{{ '/posts/' | relative_url }}">Posts</a>
+  <a href="{{ '/about/' | relative_url }}">About</a>
   <a href="{{ '/research/' | relative_url }}">Research</a>
   <a href="{{ '/publications/' | relative_url }}">Publications</a>
   <a href="{{ '/presentations/' | relative_url }}">Presentations</a>


### PR DESCRIPTION
## Summary
- add About tab to landing page
- reorder header navigation to match new tabs

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile)*

------
https://chatgpt.com/codex/tasks/task_e_684158f031c08325b5d0517b07aacb4c