### PR TITLE
Customize link colors

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -27,7 +27,7 @@ author:
       icon: "fas fa-fw fa-graduation-cap"
       url: "https://scholar.google.com/citations?user=Pe4aDh4AAAAJ&hl=en"
 
-minimal_mistakes_skin: "contrast"
+minimal_mistakes_skin: "plum"
 locale: "en"
 markdown: kramdown
 highlighter: rouge

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1,0 +1,20 @@
+---
+---
+
+@import "minimal-mistakes/skins/plum";
+@import "minimal-mistakes";
+
+/* Custom overrides */
+a {
+  color: #800080;
+}
+
+a:hover {
+  color: #a033a0;
+}
+
+.page__title {
+  font-size: 1.6em;
+  color: #800080;
+}
+


### PR DESCRIPTION
## Summary
- tweak site style to match Hanne Oberman's color palette
- apply plum skin and override link and header styles

## Testing
- `bundle exec jekyll build` *(fails: `bundler: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684161427ca08325acbc177febcbc30a